### PR TITLE
Enable to set a description to security group rules

### DIFF
--- a/lib/NIFTY/Cloud/security_groups.rb
+++ b/lib/NIFTY/Cloud/security_groups.rb
@@ -67,7 +67,8 @@ module NIFTY
                                        :in_out       => 'InOut', 
                                        :user_id => 'Groups', 
                                        :group_name => 'Groups', 
-                                       :cidr_ip => 'IpRanges'}, 
+                                       :cidr_ip => 'IpRanges',
+                                       :description => 'Description'},
                                        { :user_id => 'UserId', 
                                          :group_name => 'GroupName', 
                                          :cidr_ip => 'CidrIp'}))


### PR DESCRIPTION
Allow you to set a description for each rule in the security group.